### PR TITLE
imagesize 1.3.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,18 +17,26 @@ requirements:
   host:
     - python
     - pip
+    - setuptools
+    - wheel
   run:
-    - python
+    - python >=3.4
 
 test:
   imports:
     - imagesize
+  requires:
+    - pip
+    - python <3.10
+  commands:
+    - pip check
 
 about:
   home: https://github.com/shibukawa/imagesize_py
   license: MIT
+  license_family: MIT
   license_file: LICENSE.rst
-  summary: 'Getting image size from png/jpeg/jpeg2000/gif file'
+  summary: Getting image size from png/jpeg/jpeg2000/gif file
   description: |
     This module analyzes jpeg/jpeg2000/png/gif image header and
     return image size.

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "1.2.0" %}
+{% set version = "1.3.0" %}
 
 package:
   name: imagesize
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/i/imagesize/imagesize-{{ version }}.tar.gz
-  sha256: b1f6b5a4eab1f73479a50fb79fcf729514a900c341d8503d62a62dbc4127a2b1
+  sha256: cd1750d452385ca327479d45b64d9c7729ecf0b3969a58148298c77092261f9d
 
 build:
   noarch: python


### PR DESCRIPTION
Update imagesize to 1.3.0

Version change: bump version number from 1.2.0 to 1.3.0
Requirements from conda-forge: https://github.com/conda-forge/imagesize-feedstock/blob/master/recipe/meta.yaml
Bug Tracker: new open issues [/issues](https://github.com/shibukawa/imagesize_py/issues)
Upstream license: https://github.com/shibukawa/imagesize_py/blob/master/LICENSE.rst
Setup file: https://github.com/shibukawa/imagesize_py/blob/1.3.0/setup.py

The package imagesize is mentioned inside the packages:
 sphinx |

Actions:
1. Fix python
2. Add missing packages
3. Add pip check
4. Add license_family

Result:
- all-succeeded
