### PR TITLE
imagesize 1.4.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -30,7 +30,7 @@ test:
   commands:
     - pip check
   downstreams:
-    - sphinx
+    - sphinx  # [not py==310]
 
 about:
   home: https://github.com/shibukawa/imagesize_py

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,6 +11,7 @@ source:
 
 build:
   number: 0
+  skip: True  # [py<34]
   script: {{ PYTHON }} -m pip install . --no-deps -vv
 
 requirements:
@@ -29,8 +30,6 @@ test:
     - pip
   commands:
     - pip check
-  downstreams:
-    - sphinx  # [not py==310]
 
 about:
   home: https://github.com/shibukawa/imagesize_py

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -29,6 +29,8 @@ test:
     - pip
   commands:
     - pip check
+  downstreams:
+    - sphinx
 
 about:
   home: https://github.com/shibukawa/imagesize_py

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,15 +1,15 @@
-{% set version = "1.3.0" %}
+{% set name = "imagesize" %}
+{% set version = "1.4.1" %}
 
 package:
-  name: imagesize
+  name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/i/imagesize/imagesize-{{ version }}.tar.gz
-  sha256: cd1750d452385ca327479d45b64d9c7729ecf0b3969a58148298c77092261f9d
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: 69150444affb9cb0d5cc5a92b3676f0b2fb7cd9ae39e947a5e11a36b4497cd4a
 
 build:
-  noarch: python
   number: 0
   script: {{ PYTHON }} -m pip install . --no-deps -vv
 
@@ -20,14 +20,13 @@ requirements:
     - setuptools
     - wheel
   run:
-    - python >=3.4
+    - python
 
 test:
   imports:
     - imagesize
   requires:
     - pip
-    - python <3.10
   commands:
     - pip check
 


### PR DESCRIPTION
Upstream license: https://github.com/shibukawa/imagesize_py/blob/master/LICENSE.rst
Setup file: https://github.com/shibukawa/imagesize_py/blob/1.4.1/setup.py

The package imagesize is mentioned inside the packages:
sphinx |

Actions:
1. Remove noarch